### PR TITLE
Do not use require in package code

### DIFF
--- a/R/bit-package.R
+++ b/R/bit-package.R
@@ -18,14 +18,12 @@ NULL
 
 # devtools::use_vignette("bit-usage")
 # devtools::use_vignette("bit-performance")
-require(rhub)
-rhub_bit_4.0.3 <- check_for_cran(
-  path = "../bit_4.0.3.tar.gz"
-, email = "Jens.Oehlschlaegel@truecluster.com"
-, check_args = "--as-cran"
-, env_vars = c('_R_CHECK_FORCE_SUGGESTS_'= "false",'_R_CHECK_CRAN_INCOMING_USE_ASPELL_'= "true", '_R_CHECK_XREFS_MIND_SUSPECT_ANCHORS_'="true")
-, platforms = NULL
-, show_status = FALSE
-)
-
-
+## require(rhub)
+## rhub_bit_4.0.3 <- check_for_cran(
+##   path = "../bit_4.0.3.tar.gz"
+## , email = "Jens.Oehlschlaegel@truecluster.com"
+## , check_args = "--as-cran"
+## , env_vars = c('_R_CHECK_FORCE_SUGGESTS_'= "false",'_R_CHECK_CRAN_INCOMING_USE_ASPELL_'= "true", '_R_CHECK_XREFS_MIND_SUSPECT_ANCHORS_'="true")
+## , platforms = NULL
+## , show_status = FALSE
+## )


### PR DESCRIPTION
@lsilvest alerted me to the fact that bit 4.0.3 did not build off GitHub which I confirmed.  Took a second to grok that the error of

```
[....]
installing to /usr/local/lib/R/site-library/00LOCK-bit/00new/bit/libs
** R
** byte-compile and prepare package for lazy loading
Warning in normalizePath(path) :
  path[1]="../bit_4.0.3.tar.gz": No such file or directory
Error : path is not an R package directory or source R package
Error: unable to load R code in package ‘bit’
Execution halted
ERROR: lazy loading failed for package ‘bit’
[....]
```

was of course one I had seen before too.  Byte-compiling fails when have play with forbidden fruits in package code.  

So the simple PR fixes this by removing the `require(rhub)` you left in what is clearly meant to be local code. And with `rhub` out the next line using it also goes.  [1]   The rest is unchanged, and it installs and tests just fine after the change.


[1] For what it is worth I do all that from `littler` with a script called `c4c.r` calling `check_for_cran()`, I could add the extra env vars you have here.  See https://github.com/eddelbuettel/littler/blob/master/inst/examples/c4c.r and the repo has a few more architecture-specific RHub calling wrappers...